### PR TITLE
Fixed usage of instance variable to accessor method

### DIFF
--- a/libraries/node_ext.rb
+++ b/libraries/node_ext.rb
@@ -15,10 +15,10 @@ class Chef
       if Chef::Config[:solo]
         Chef::Log.debug("Saving the current state of node #{node_name}")
         if(@original_runlist)
-          @node.run_list(*@original_runlist)
-          @node[:runlist_override_history] = {Time.now.to_i => @override_runlist.inspect}
+          node.run_list(*@original_runlist)
+          node[:runlist_override_history] = {Time.now.to_i => @override_runlist.inspect}
         end
-        @node.save
+        node.save
       else
         original_save_updated_node
       end


### PR DESCRIPTION
Made the extension use `node` accessor instead of `@node` instance variable.

In recent versions of Chef (somewhere since May, 2015) `node` is no longer `Client`'s instance variable, it is now stored inside another object. Accessors for it are available anyway since the beginning of Chef, so they should be used instead.